### PR TITLE
Disable broken Tree Header indicator.

### DIFF
--- a/Kvantum/Matcha-sea-dark/Matcha-sea-dark.kvconfig
+++ b/Kvantum/Matcha-sea-dark/Matcha-sea-dark.kvconfig
@@ -306,7 +306,7 @@ text.bold=true
 text.normal.color=#d3dae3
 text.focus.color=#ffffff
 text.toggle.color=#ffffff
-indicator.element=harrow
+#indicator.element=harrow
 frame.expansion=0
 
 [SizeGrip]

--- a/Kvantum/Matcha-sea/Matcha-sea.kvconfig
+++ b/Kvantum/Matcha-sea/Matcha-sea.kvconfig
@@ -306,7 +306,7 @@ text.bold=true
 text.normal.color=#303d41
 text.focus.color=#4c85cb
 text.toggle.color=#32343D
-indicator.element=harrow
+#indicator.element=harrow
 frame.expansion=0
 
 [SizeGrip]


### PR DESCRIPTION
On [Manjaro with KDE](https://packages.manjaro.org/?query=kvantum-theme-matcha), the little arrow that shows which column is being used for sorting in a list view, and whether it's in ascending or descending order, wasn't showing in QT apps like Dolphin.

Commenting out these lines fixed it for me.

I based this change on what I had to do in my system files, but I checked that the `.kvconfig` and `.svg` files were identical to the ones in this repo.